### PR TITLE
client and server commands for standalone usage

### DIFF
--- a/client.py
+++ b/client.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
     if len(sys.argv) != 3:
         printUsage()
         exit(1)
-    
+
     # Parse arguments
     bootstrapHost = sys.argv[1]
     fileHash = sys.argv[2]
@@ -24,4 +24,10 @@ if __name__ == '__main__':
     print("Getting file with hash: {}".format(fileHash))
 
     ipfsNode = IPFSNode(bootstrapHost)
-    retrievedFile = ipfsNode.getFile(fileHash)
+    (retrievedFile, metadata) = ipfsNode.getFile(fileHash)
+    print("Saving downloaded file to {}.download".format(metadata['fileName']))
+    
+    # Save file
+    with open(metadata['fileName'] + '.download', 'wb') as f:
+        f.write(retrievedFile)
+    exit(0)

--- a/client.py
+++ b/client.py
@@ -6,25 +6,22 @@ import sys
 from main import IPFSNode
 
 def printUsage():
-    print("Usage: client <listen port> <bootstrap IP> <bootstrap port> <file hash>")
+    print("Usage: client <bootstrap IP> <file hash>")
     print()
     print("Retrieves a file from the IPFS network. "
           "Provide a bootstap node as an entry point to the network. "
           "Provide the SHA-512 hash of the file to retrieve.")
 
 if __name__ == '__main__':
-    if len(sys.argv) != 5:
+    if len(sys.argv) != 3:
         printUsage()
         exit(1)
     
     # Parse arguments
-    listenPort = int(sys.argv[1])
-    bootstrapHost = sys.argv[2]
-    bootstrapPort = int(sys.argv[3])
-    fileHash = sys.argv[4]
-    print("Listen on port: {}".format(listenPort))
-    print("Bootstrap node: {}:{}".format(bootstrapHost, bootstrapPort))
+    bootstrapHost = sys.argv[1]
+    fileHash = sys.argv[2]
+    print("Bootstrap node: {}".format(bootstrapHost))
     print("Getting file with hash: {}".format(fileHash))
 
-    ipfsNode = IPFSNode(listenPort, bootstrapHost, bootstrapPort)
+    ipfsNode = IPFSNode(bootstrapHost)
     retrievedFile = ipfsNode.getFile(fileHash)

--- a/client.py
+++ b/client.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sys
+
+from main import IPFSNode
+
+def printUsage():
+    print("Usage: client <listen port> <bootstrap IP> <bootstrap port> <file hash>")
+    print()
+    print("Retrieves a file from the IPFS network. "
+          "Provide a bootstap node as an entry point to the network. "
+          "Provide the SHA-512 hash of the file to retrieve.")
+
+if __name__ == '__main__':
+    if len(sys.argv) != 5:
+        printUsage()
+        exit(1)
+    
+    # Parse arguments
+    listenPort = int(sys.argv[1])
+    bootstrapHost = sys.argv[2]
+    bootstrapPort = int(sys.argv[3])
+    fileHash = sys.argv[4]
+    print("Listen on port: {}".format(listenPort))
+    print("Bootstrap node: {}:{}".format(bootstrapHost, bootstrapPort))
+    print("Getting file with hash: {}".format(fileHash))
+
+    ipfsNode = IPFSNode(listenPort, bootstrapHost, bootstrapPort)
+    retrievedFile = ipfsNode.getFile(fileHash)

--- a/client.py
+++ b/client.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import sys
+import os
 
 from main import IPFSNode
 
@@ -30,4 +31,4 @@ if __name__ == '__main__':
     # Save file
     with open(metadata['fileName'] + '.download', 'wb') as f:
         f.write(retrievedFile)
-    exit(0)
+    os._exit(0)

--- a/dht_bootstrap_node.py
+++ b/dht_bootstrap_node.py
@@ -3,10 +3,10 @@ import asyncio
 
 from kademlia.network import Server
 
-def launch_bootstrap():
+def launch_bootstrap(listenPort: int = 8468):
     
     server = Server()
-    server.listen(8468)
+    server.listen(listenPort)
     
     loop = asyncio.get_event_loop()
     loop.set_debug(True)

--- a/dht_bootstrap_node.py
+++ b/dht_bootstrap_node.py
@@ -3,10 +3,10 @@ import asyncio
 
 from kademlia.network import Server
 
-def launch_bootstrap(listenPort: int = 8468):
+def launch_bootstrap():
     
     server = Server()
-    server.listen(listenPort)
+    server.listen(8468)
     
     loop = asyncio.get_event_loop()
     loop.set_debug(True)

--- a/dht_bootstrap_node.py
+++ b/dht_bootstrap_node.py
@@ -6,7 +6,7 @@ from kademlia.network import Server
 def launch_bootstrap():
     
     server = Server()
-    server.listen(8468)
+    server.listen(8469)
     
     loop = asyncio.get_event_loop()
     loop.set_debug(True)

--- a/main.py
+++ b/main.py
@@ -197,7 +197,7 @@ class IPFSNode():
         
         return data
     
-    def getFile(self, hsh: str) -> bytes:
+    def getFile(self, hsh: str) -> (bytes, dict):
         masterFileRecord = self.getDHTKey(hsh) #Get metadata
         metadata = None
         
@@ -227,7 +227,7 @@ class IPFSNode():
             
         if metadata['compression']:
             fileContents = zlib.decompress(fileContents)
-        return fileContents
+        return (fileContents, metadata)
     
     def __del__(self):
         self.server.stop()
@@ -251,6 +251,6 @@ if __name__ == '__main__':
        storedHash = ipfsNode.addFile('./LICENSE', False)
        print("{} stored on IPFS".format(storedHash))
        
-       retrievedFile = ipfsNode.getFile(storedHash)
+       (retrievedFile, metadata) = ipfsNode.getFile(storedHash)
        
        print(b"Original file contents recovered:\n" + retrievedFile)

--- a/main.py
+++ b/main.py
@@ -55,14 +55,14 @@ class List():
                     'fileLen' : self.fileLen, 'links' : self.links, 'compression' : self.compression})
         
 class IPFSNode():
-    def __init__ (self, listenPort: int = 8469, bootstrapHost: str = 'bootstrap', bootstrapPort: int = 8468):
+    def __init__ (self, bootstrapHost: str = 'bootstrap'):
         self.server = Server()
-        self.server.listen(listenPort)
+        self.server.listen(8469)
         self.has_list = []
         
         self.local_ip = socket.gethostbyname(socket.gethostname())
         bootstrap_ip = socket.gethostbyname(bootstrapHost)
-        self.bootstrap_node = (bootstrap_ip, bootstrapPort)
+        self.bootstrap_node = (bootstrap_ip, 8469)
         
         self.loop = asyncio.get_event_loop()
         self.loop.set_debug(True)

--- a/main.py
+++ b/main.py
@@ -60,7 +60,13 @@ class IPFSNode():
         self.server.listen(8469)
         self.has_list = []
         
-        self.local_ip = socket.gethostbyname(socket.gethostname())
+        # Hack to get the "deafult" IP
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(('1.1.1.1', 80))
+        self.local_ip = s.getsockname()[0]
+        s.close()
+
+        #self.local_ip = socket.gethostbyname(socket.gethostname())
         bootstrap_ip = socket.gethostbyname(bootstrapHost)
         self.bootstrap_node = (bootstrap_ip, 8469)
         

--- a/main.py
+++ b/main.py
@@ -191,7 +191,7 @@ class IPFSNode():
         
         return data
     
-    def getFile(self, hsh: str):
+    def getFile(self, hsh: str) -> bytes:
         masterFileRecord = self.getDHTKey(hsh) #Get metadata
         metadata = None
         

--- a/main.py
+++ b/main.py
@@ -55,14 +55,14 @@ class List():
                     'fileLen' : self.fileLen, 'links' : self.links, 'compression' : self.compression})
         
 class IPFSNode():
-    def __init__ (self):
+    def __init__ (self, listenPort: int = 8469, bootstrapHost: str = 'bootstrap', bootstrapPort: int = 8468):
         self.server = Server()
-        self.server.listen(8469)
+        self.server.listen(listenPort)
         self.has_list = []
         
         self.local_ip = socket.gethostbyname(socket.gethostname())
-        bootstrap_ip = socket.gethostbyname('bootstrap')
-        self.bootstrap_node = (bootstrap_ip, 8468)
+        bootstrap_ip = socket.gethostbyname(bootstrapHost)
+        self.bootstrap_node = (bootstrap_ip, bootstrapPort)
         
         self.loop = asyncio.get_event_loop()
         self.loop.set_debug(True)

--- a/server.py
+++ b/server.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import sys
+import asyncio
 
 from main import IPFSNode
 from dht_bootstrap_node import launch_bootstrap
@@ -37,3 +38,14 @@ if __name__ == '__main__':
     if fileName != None:
         print("Adding file to IPFS network")
         ipfsNode.addFile(fileName, False)
+    
+    loop = asyncio.get_event_loop()
+    loop.set_debug(True)
+    
+    try:
+        loop.run_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        ipfsNode.server.stop()
+    loop.close()

--- a/server.py
+++ b/server.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sys
+
+from main import IPFSNode
+from dht_bootstrap_node import launch_bootstrap
+
+def printUsage():
+    print("Usage: server <listen port> [<bootstrapHost> <bootstrapPort> [<file>]]")
+    print()
+    print("Starts a node on the IPFS network. "
+          "If the optional bootstrap node is provided, it will connect to an "
+          "existing IPFS network.")
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2 and len(sys.argv) != 4 and len(sys.argv) != 5:
+        printUsage()
+        exit(1)
+    
+    # Parse arguments
+    listenPort = int(sys.argv[1])
+    print("Listen on port: {}".format(listenPort))
+    if len(sys.argv) >= 4:
+        bootstrapHost = sys.argv[2]
+        bootstrapPort = int(sys.argv[3])
+        print("Bootstrap node: {}:{}".format(bootstrapHost, bootstrapPort))
+        if len(sys.argv) == 5:
+            fileName = sys.argv[4]
+        else:
+            fileName = None
+    else:
+        print("Launching bootstrap node")
+        launch_bootstrap(listenPort)
+        exit(0)
+
+    print("Connecting to existing IPFS network")
+    ipfsNode = IPFSNode(listenPort, bootstrapHost, bootstrapPort)
+
+    if fileName != None:
+        print("Adding file to IPFS network")
+        ipfsNode.addFile(fileName, False)

--- a/server.py
+++ b/server.py
@@ -7,35 +7,32 @@ from main import IPFSNode
 from dht_bootstrap_node import launch_bootstrap
 
 def printUsage():
-    print("Usage: server <listen port> [<bootstrapHost> <bootstrapPort> [<file>]]")
+    print("Usage: server [<bootstrapHost> [<file>]]")
     print()
     print("Starts a node on the IPFS network. "
           "If the optional bootstrap node is provided, it will connect to an "
           "existing IPFS network.")
 
 if __name__ == '__main__':
-    if len(sys.argv) != 2 and len(sys.argv) != 4 and len(sys.argv) != 5:
+    if len(sys.argv) > 3:
         printUsage()
         exit(1)
     
     # Parse arguments
-    listenPort = int(sys.argv[1])
-    print("Listen on port: {}".format(listenPort))
-    if len(sys.argv) >= 4:
-        bootstrapHost = sys.argv[2]
-        bootstrapPort = int(sys.argv[3])
-        print("Bootstrap node: {}:{}".format(bootstrapHost, bootstrapPort))
-        if len(sys.argv) == 5:
-            fileName = sys.argv[4]
+    if len(sys.argv) >= 2:
+        bootstrapHost = sys.argv[1]
+        print("Bootstrap node: {}".format(bootstrapHost))
+        if len(sys.argv) == 3:
+            fileName = sys.argv[2]
         else:
             fileName = None
     else:
         print("Launching bootstrap node")
-        launch_bootstrap(listenPort)
+        launch_bootstrap()
         exit(0)
 
     print("Connecting to existing IPFS network")
-    ipfsNode = IPFSNode(listenPort, bootstrapHost, bootstrapPort)
+    ipfsNode = IPFSNode(bootstrapHost)
 
     if fileName != None:
         print("Adding file to IPFS network")


### PR DESCRIPTION
Added client.py and server.py to allow the 4 following node operation modes:
* bootstrap node
* node joining to bootstrap node
* node joining to bootstrap node and adding a file
* node requesting a file (by a hash)